### PR TITLE
Replace the old youtube-dl download link with the new one

### DIFF
--- a/youtube_dl_gui/updatemanager.py
+++ b/youtube_dl_gui/updatemanager.py
@@ -45,7 +45,7 @@ class UpdateThread(Thread):
 
     """
 
-    LATEST_YOUTUBE_DL = 'https://yt-dl.org/latest/'
+    LATEST_YOUTUBE_DL = 'https://youtube-dl.org/downloads/latest/'
     DOWNLOAD_TIMEOUT = 10
 
     def __init__(self, download_path, quiet=False):


### PR DESCRIPTION
This pull request fixes MrS0m30n3/youtube-dl-gui#484 by replacing the old download url with the new one.